### PR TITLE
Make config script GCC 5.x aware

### DIFF
--- a/config
+++ b/config
@@ -293,7 +293,7 @@ IFS=.
 set -- ${vers}
 IFS="$OIFS"
 
-if [ $1 -lt 4 -o $2 -lt 4 ]
+if [ $1 -lt 4 ] || [ $1 -eq 4 -a $2 -lt 4 ]
 then
 	echo "ERROR:"
 	echo "GCC version 4.4 or above is required."
@@ -804,3 +804,7 @@ s#@WAVPACK_LIBSPEC@#${wavpack_libspec}#g
 s#@WAVPACK_DIR@#${wavpack_dir}#g
 " > Makefile
 
+if [ "x${enable_wavpack}" == "x" ]
+then
+    sed -i -e '/^WAVPKSRCS/ D' -e '/^WAVPKOBJS/ D' Makefile
+fi


### PR DESCRIPTION
This patch makes two little things:
1. makes config script GCC 5.x friendly
2. completely removes wavpack related stuff from Makefile if --disable-wavpack given
Second one for #24 and #35 issues. I also stuck into this when compiling w/o wavpack.
Compiled with this patch by gcc 5.1.0 on ArchLinux x86_64 from git master:
cd pcompress-master
patch -Np1 < ../gcc5.patch
./config --prefix=/usr --no-1.3-archive-compat --disable-wavpack
make
make install
have no problems and works fine.