### PR TITLE
Adds missing check for pctx->main_cancel

### DIFF
--- a/pcompress.c
+++ b/pcompress.c
@@ -1729,6 +1729,9 @@ redo:
 			if (p == np) continue;
 			tdat = dary[p];
 			Sem_Wait(&tdat->write_done_sem);
+// VS begin
+			if (pctx->main_cancel) break;
+// VS end
 		}
 	}
 uncomp_done:


### PR DESCRIPTION
While decompressing (-d) after done reading from the input file, the main thread just waits until writer_thread complete writing of the next block. In turn writer_thread waits until perform_decompress will decompress this block. When error occurs in the perform_decompress thread he sets pctx->main_cancel = 1, sends signal to writer_thread via Sem_Post(&tdat->cmp_done_sem) end exits. writer_thread looks at pctx->main_cancel and seeing that pctx->main_cancel = 1 in turn sends signal Sem_Post(&tdat->write_done_sem) and also ends his run. Main thread receives tdat->write_done_sem, but does not check if pctx->main_cancel = 1. Instead he simply goes to the next thread and again waits for tdat->write_done_sem. But writer_thread already exited and nobody will send this signal again. This patch simply adds missing pctx->main_cancel = 1 check to the main thread's loop.