### PR TITLE
Add OpenSSL incdir libdir flags to ./config

### DIFF
--- a/config
+++ b/config
@@ -200,6 +200,12 @@ do
 		pval=`echo ${arg1} | cut -f2 -d"="`
 		prefix=$pval
 	;;
+	--with-openssl-libdir=*)
+		openssl_libdir=`echo ${arg1} | cut -f2 -d"="`
+	;;
+	--with-openssl-incdir=*)
+		openssl_incdir=`echo ${arg1} | cut -f2 -d"="`
+	;;
 	--with-openssl=*)
 		openssl_prefix=`echo ${arg1} | cut -f2 -d"="`
 	;;
@@ -433,7 +439,8 @@ fi
 
 # Detect OpenSSL library
 echo "Checking for OpenSSL ..."
-for lib in "${openssl_prefix}/lib64" "${openssl_prefix}/usr/lib64" \
+for lib in "${openssl_libdir}" \
+        "${openssl_prefix}/lib64" "${openssl_prefix}/usr/lib64" \
 	"${openssl_prefix}/lib" "${openssl_prefix}/usr/lib" \
 	"${openssl_prefix}/ssl/lib64" "${openssl_prefix}/ssl/lib" \
 	"${openssl_prefix}/lib/x86_64-linux-gnu" \
@@ -464,7 +471,8 @@ then
 fi
 
 # Detect OpenSSL headers
-for inc in "${openssl_prefix}/include" \
+for inc in "${openssl_incdir}" \
+        "${openssl_prefix}/include" \
 	"${openssl_prefix}/usr/include" \
 	"${openssl_prefix}/ssl/include"
 do


### PR DESCRIPTION
Allow to use distro OpenSSL 1.0 package with separate include
and library directory.
#### Example: ArchLinux:openssl-1.0
* libdir: /usr/lib/openssl-1.0
* incdir: /usr/include/openssl-1.0